### PR TITLE
build: link against all required spinnaker libs.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ target_link_libraries(${PROJECT_NAME}_node
   ${catkin_LIBRARIES}
 )
 
-FILE(GLOB SpinLibs ${Spinnaker_LIBRARIES}/libSpin*.so)
+FILE(GLOB SpinLibs ${Spinnaker_LIBRARY_DIRS}/libSpin*.so)
 
 add_library(BosonCameraEthernet
   src/nodelets/BaseCameraController.cpp


### PR DESCRIPTION
leverage an update to the FindSpinnaker.cmake file (which defines Spinnaker_LIBRARY_DIRS) to fix the glob expression that gathers all of the required libraries for linking.

this fixes the missing spinnaker symbol uncovered during runtime loading of the boson ethernet module.